### PR TITLE
fixed dockerfile of production to add only the dist folder

### DIFF
--- a/docker/node/Dockerfile.prod
+++ b/docker/node/Dockerfile.prod
@@ -8,7 +8,7 @@ RUN npm run build
 
 FROM node:20.17-slim AS production
 WORKDIR /home/node/app
-COPY --from=builder /home/node/app .
+COPY --from=builder /home/node/app/dist .
 
 ENV TZ=Europe/Paris
 
@@ -16,4 +16,4 @@ EXPOSE 3000
 
 USER node
 
-CMD ["node", "dist/server.js"]
+CMD ["node", "server.js"]


### PR DESCRIPTION
## Description
- change the dockerfile of production to copy only the dist folder and not all the source files.

## Docker build
- YES (Prod only)

## How Has This Been Tested?
- tested with unit test and vps 
- tested on macos